### PR TITLE
Tell the user when they can reveal surrounding

### DIFF
--- a/src/gamelogic/types.ts
+++ b/src/gamelogic/types.ts
@@ -29,7 +29,8 @@ export interface Cell {
   id: number;
   tag: Tag;
   revealed: boolean;
-  touching: number;
+  touchingMines: number;
+  touchingFlags: number;
 }
 
 export type GridChanges = Array<[number, number, Cell]>;

--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -15,7 +15,7 @@ import { Component, h } from "preact";
 import StateService from "src/services/state";
 import { bind } from "src/utils/bind";
 import { GridChangeSubscriptionCallback } from "../..";
-import { Cell } from "../../../../gamelogic/types";
+import { Cell, Tag } from "../../../../gamelogic/types";
 import Board from "../board";
 import { checkbox, toggle, toggleLabel } from "./style.css";
 
@@ -65,19 +65,23 @@ export default class Game extends Component<Props, State> {
   }
 
   @bind
-  private onCellClick(cell: [number, number, string], forceAlt: boolean) {
-    const [x, y, state] = cell;
+  private onCellClick(cellData: [number, number, Cell], forceAlt: boolean) {
+    const [x, y, cell] = cellData;
     const { altActionChecked } = this.state;
 
     const altAction = forceAlt || altActionChecked;
 
-    if (state === "unrevealed" && !altAction) {
-      this.props.stateService.reveal(x, y);
-    } else if (state === "unrevealed" && altAction) {
-      this.props.stateService.flag(x, y);
-    } else if (state === "flagged" && altAction) {
-      this.props.stateService.unflag(x, y);
-    } else if (Number(state) !== Number.NaN && altAction) {
+    if (!cell.revealed) {
+      if (altAction) {
+        if (cell.tag === Tag.Flag) {
+          this.props.stateService.unflag(x, y);
+        } else {
+          this.props.stateService.flag(x, y);
+        }
+      } else {
+        this.props.stateService.reveal(x, y);
+      }
+    } else if (cell.touchingFlags >= cell.touchingMines) {
       this.props.stateService.revealSurrounding(x, y);
     }
   }


### PR DESCRIPTION
(note that this doesn't merge to master)

It feels like "reveal surrounding" should be available whenever a square has the right number of flags around it. I've changed the UI so the numbers change when the correct number of flags are there.