### PR TITLE
Creating a baseline performance profile

### DIFF
--- a/src/gamelogic/index.ts
+++ b/src/gamelogic/index.ts
@@ -33,13 +33,14 @@ export default class MinesweeperGame {
   get flags() {
     return this._flags;
   }
-  static EMIT_THRESHOLD = 10;
+  static EMIT_THRESHOLD = 60;
   grid: Cell[][];
   startTime = 0;
   endTime = 0;
   private _state = State.Pending;
   private _toReveal = 0;
   private _flags = 0;
+  private _lastEmit = 0;
   private _gridChanges: Array<[number, number]> = [];
   private _changeCallback?: ChangeCallback;
 
@@ -173,8 +174,10 @@ export default class MinesweeperGame {
 
   private _pushGridChange(x: number, y: number) {
     this._gridChanges.push([x, y]);
-    if (this._gridChanges.length >= MinesweeperGame.EMIT_THRESHOLD) {
-      // this._emit();
+    let now = Date.now();
+    if (now - this._lastEmit >= MinesweeperGame.EMIT_THRESHOLD) {
+      this._emit();
+      this._lastEmit = now;
     }
   }
 
@@ -241,6 +244,7 @@ export default class MinesweeperGame {
   private _reveal(x: number, y: number) {
     // The set contains the cell position as if it were a single flat array.
     const revealSet = new Set<number>([x + y * this._width]);
+    this._lastEmit = Date.now();
 
     for (const value of revealSet) {
       const x = value % this._width;

--- a/src/gamelogic/index.ts
+++ b/src/gamelogic/index.ts
@@ -174,7 +174,7 @@ export default class MinesweeperGame {
   private _pushGridChange(x: number, y: number) {
     this._gridChanges.push([x, y]);
     if (this._gridChanges.length >= MinesweeperGame.EMIT_THRESHOLD) {
-      this._emit();
+      // this._emit();
     }
   }
 

--- a/src/gamelogic/index.ts
+++ b/src/gamelogic/index.ts
@@ -128,7 +128,9 @@ export default class MinesweeperGame {
 
     let flagged = 0;
 
-    for (const [nextX, nextY] of this._iterateSurrounding(x, y)) {
+    // Go around the surrounding. This will go over items already seen.
+    const surroundingIndecies = this.getSurrounding(x, y);
+    for (const [nextX, nextY] of surroundingIndecies) {
       const nextCell = this.grid[nextY][nextX];
       if (nextCell.tag === Tag.Flag) {
         flagged += 1;
@@ -204,10 +206,8 @@ export default class MinesweeperGame {
     this._state = State.Playing;
   }
 
-  private *_iterateSurrounding(
-    x: number,
-    y: number
-  ): IterableIterator<[number, number]> {
+  private getSurrounding(x: number, y: number): Array<[number, number]> {
+    const surrounding: Array<[number, number]> = [];
     for (const nextY of [y - 1, y, y + 1]) {
       if (nextY < 0) {
         continue;
@@ -227,9 +227,10 @@ export default class MinesweeperGame {
           continue;
         }
 
-        yield [nextX, nextY];
+        surrounding.push([nextX, nextY]);
       }
     }
+    return surrounding;
   }
 
   /**
@@ -269,8 +270,9 @@ export default class MinesweeperGame {
       let touching = 0;
       const maybeReveal: number[] = [];
 
-      // Go around the surrounding squares
-      for (const [nextX, nextY] of this._iterateSurrounding(x, y)) {
+      // Go around the surrounding. This will go over items already seen.
+      const surroundingIndecies = this.getSurrounding(x, y);
+      for (const [nextX, nextY] of surroundingIndecies) {
         const nextCell = this.grid[nextY][nextX];
 
         if (nextCell.hasMine) {


### PR DESCRIPTION
Create a baseline for performance, after a quick analysis of the performance of the game on a pixel book, I saw the following performance characteristics on 40x40 grid with 100 bombs

I set a baseline of how long it takes to iterate across an entire array of 1600 elements and also 1600 * 8 because the current algorithm potentially iterates across each grid item 8 times.

```
test = (count) => {
  let c = new Array(count).fill({ test: true, test1: 4 },0, count);
  performance.mark('start')
  for(let i of c) {
    let d = i;
  }
  performance.mark('end');
  performance.measure('test', 'start','end');
}
```


It took roughly 6ms on a pixelbook - yes, it's not ideal, but it indicates a possible fastest performance in the worst possible case, and it took 31ms including a GC in the middle on the Alcatel.

**Pixelbook**

* [Current Algorithm] General incremental reveal algorithm took between 50-80ms on a Pixelbook and incremental reveal took another 70ms - currently counting 135ms from Worker receiving message to full board reveal. The reveal feels jaring and inconsistent across devices.
* [No Generator, incremental reveal] took incremental reveal out by removing generator code and saw the reveal algorithm take consistently 30ms with the Worker message passing taking, closer to 26ms baseline, and then it took another 70ms to complete the game board reveal
* [No Generator, full reveal] I removed the incremental reveal just passed the game state at the end and it took 30ms for algorithm in worker, and 15ms for the full game state to reveal.

**Alcatel Android Go**

* [Current Algorithm] General incremental reveal with iterators takes 400ms-700ms and then 500ms to complete the DOM updates and reveal. The reveal feels generally slow and the UI update doesn't feel like an animation. I would expect if we are animating then we would get a similar speed to pixelbook, but it just feels off. :\
* [No Generator, incremental reveal] about 300ms to do the reveal logic and again a consistent 500ms to get all the DOM updates out.
* I removed the incremental reveal just passed the game state at the end and it took 140ms for algorithm in worker, and 140ms for the full game state to reveal. It generally felt faster in all aspects.

**General analysis**

* Remove the generators
* My reading of the algorithm in the worst case is reading each cell roughly 8 times to check to see if it should reveal or not. It does feel like this is a variant of the flood fill algorithm and we should be able to massively optimise this across all devices - I wouldn't be surprised if you can get this to be sub 30ms across all devices in the worker.
* The chatty interface for updating the DOM is causing a huge performance penalty that I believe will make it impossible to get consistent animations and performance across all devices. On Alcatel phones the way you send updates is 350ms penalty (3.5x penalty on what I could get), on Pixel book its a 50ms penalty (although it's really a 4x penalty on this device)
* If you are persistent on incremental update of the UI, it only might make a difference on the low-end phones. For pixelbooks (and even some light testing on pixelphone), even for large boards full reveal is far far below all 100ms budgets for response and UI update is consistently sub-frame 16ms. My initial feel is that you can do the full analysis on all devices in the worker in under 100ms in nearly all cases, and then animate your UI however you want without the forced performance penalties that we are seeing with sending chunks of updates through.

