### PR TITLE
add aria-label to table and buttons

### DIFF
--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -143,7 +143,7 @@ export default class Board extends Component<Props> {
         const button = document.createElement("button");
         button.classList.add(buttonStyle);
         this.additionalButtonData.set(button, [x, y, defaultCell]);
-        this.updateButton(button, defaultCell);
+        this.updateButton(button, defaultCell, x, y);
         this.buttons.push(button);
         td.appendChild(button);
         tr.appendChild(td);
@@ -325,7 +325,7 @@ export default class Board extends Component<Props> {
     const slice = this.changeBuffer.splice(0, numConsume);
     for (const [x, y, cellProps] of slice) {
       const btn = this.buttons[y * width + x];
-      this.updateButton(btn, cellProps);
+      this.updateButton(btn, cellProps, x, y);
       this.cellsToRedraw.add(btn);
       this.updateAnimation(btn);
     }
@@ -384,14 +384,21 @@ export default class Board extends Component<Props> {
     this.props.onCellClick(cell, alt);
   }
 
-  private updateButton(btn: HTMLButtonElement, cell: Cell) {
+  private updateButton(
+    btn: HTMLButtonElement,
+    cell: Cell,
+    x: number,
+    y: number
+  ) {
     const cellState = !cell.revealed
       ? cell.flagged
-        ? "flagged"
-        : "unrevealed"
+        ? `flag at ${x + 1}, ${y + 1}`
+        : `hidden at ${x + 1}, ${y + 1}`
       : cell.hasMine
-      ? "mine"
-      : `${cell.touchingMines}`;
+      ? `mine at ${x + 1}, ${y + 1}` // should it say black hole?
+      : cell.touchingMines === 0
+      ? `blank at ${x + 1}, ${y + 1}`
+      : `${cell.touchingMines} at ${x + 1}, ${y + 1}`;
 
     btn.setAttribute("aria-label", cellState);
     this.additionalButtonData.get(btn)![2] = cell;

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -132,8 +132,6 @@ export default class Board extends Component<Props> {
     const tableContainer = document.querySelector("." + containerStyle);
     this.table = document.createElement("table");
     this.table.classList.add(gameTable);
-    this.table.tabIndex = 1;
-    this.table.setAttribute("aria-label", `field of ${width} by ${height}`);
     for (let row = 0; row < height; row++) {
       const tr = document.createElement("tr");
       tr.classList.add(gameRow);

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -393,9 +393,9 @@ export default class Board extends Component<Props> {
     let cellState;
     const position = `${x + 1}, ${y + 1}`;
     if (!cell.revealed) {
-      cell.flagged
-        ? (cellState = `flag at ${position}`)
-        : (cellState = `hidden at ${position}`);
+      cellState = cell.flagged
+        ? `flag at ${position}`
+        : `hidden at ${position}`;
     } else if (cell.hasMine) {
       cellState = `mine at ${position}`; // should it say black hole?
     } else if (cell.touchingMines === 0) {

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -132,6 +132,8 @@ export default class Board extends Component<Props> {
     const tableContainer = document.querySelector("." + containerStyle);
     this.table = document.createElement("table");
     this.table.classList.add(gameTable);
+    this.table.tabIndex = 1;
+    this.table.setAttribute("aria-label", `field of ${width} by ${height}`);
     for (let row = 0; row < height; row++) {
       const tr = document.createElement("tr");
       tr.classList.add(gameRow);

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -391,17 +391,17 @@ export default class Board extends Component<Props> {
     y: number
   ) {
     let cellState;
-
+    const position = `${x + 1}, ${y + 1}`;
     if (!cell.revealed) {
       cell.flagged
-        ? (cellState = `flag at ${x + 1}, ${y + 1}`)
-        : (cellState = `hidden at ${x + 1}, ${y + 1}`);
+        ? (cellState = `flag at ${position}`)
+        : (cellState = `hidden at ${position}`);
     } else if (cell.hasMine) {
-      cellState = `mine at ${x + 1}, ${y + 1}`; // should it say black hole?
+      cellState = `mine at ${position}`; // should it say black hole?
     } else if (cell.touchingMines === 0) {
-      cellState = `blank at ${x + 1}, ${y + 1}`;
+      cellState = `blank at ${position}`;
     } else {
-      cellState = `${cell.touchingMines} at ${x + 1}, ${y + 1}`;
+      cellState = `${cell.touchingMines} at ${position}`;
     }
 
     btn.setAttribute("aria-label", cellState);

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -390,15 +390,19 @@ export default class Board extends Component<Props> {
     x: number,
     y: number
   ) {
-    const cellState = !cell.revealed
-      ? cell.flagged
-        ? `flag at ${x + 1}, ${y + 1}`
-        : `hidden at ${x + 1}, ${y + 1}`
-      : cell.hasMine
-      ? `mine at ${x + 1}, ${y + 1}` // should it say black hole?
-      : cell.touchingMines === 0
-      ? `blank at ${x + 1}, ${y + 1}`
-      : `${cell.touchingMines} at ${x + 1}, ${y + 1}`;
+    let cellState;
+
+    if (!cell.revealed) {
+      cell.flagged
+        ? (cellState = `flag at ${x + 1}, ${y + 1}`)
+        : (cellState = `hidden at ${x + 1}, ${y + 1}`);
+    } else if (cell.hasMine) {
+      cellState = `mine at ${x + 1}, ${y + 1}`; // should it say black hole?
+    } else if (cell.touchingMines === 0) {
+      cellState = `blank at ${x + 1}, ${y + 1}`;
+    } else {
+      cellState = `${cell.touchingMines} at ${x + 1}, ${y + 1}`;
+    }
 
     btn.setAttribute("aria-label", cellState);
     this.additionalButtonData.get(btn)![2] = cell;


### PR DESCRIPTION
We can totally argue about what exactly should say in aria label :)
 
One question, can we pass number of mines to  `createTable` so I can label the table  `field of ${width} by ${height}, ${num of mines} mines in the field` ?

addresses half of #89 