### PR TITLE
Feature phone responsive

### DIFF
--- a/src/rendering/texture-cache.ts
+++ b/src/rendering/texture-cache.ts
@@ -14,13 +14,19 @@
 import { staticDevicePixelRatio } from "../utils/static-dpr.js";
 import { TextureGenerator } from "./texture-generators.js";
 
+export type TextureDrawer = (
+  idx: number,
+  ctx: CanvasRenderingContext2D,
+  cellSize: number
+) => void;
+
 // Wraps an existing TextureGenerator and caches the generated
 // frames in a sprite.
 export function cacheTextureGenerator(
   f: TextureGenerator,
   textureSize: number,
   numFrames: number
-): TextureGenerator {
+): TextureDrawer {
   const cacheCanvas = document.createElement("canvas");
   // Allegedly, Chrome, Firefox and Safari have a maximum canvas size of 32k
   // pixels. We are *definitely* below that, but for some reason the draws to
@@ -41,7 +47,7 @@ export function cacheTextureGenerator(
   }
   cacheCtx.scale(staticDevicePixelRatio, staticDevicePixelRatio);
 
-  return (idx: number, ctx: CanvasRenderingContext2D) => {
+  return (idx: number, ctx: CanvasRenderingContext2D, cellSize: number) => {
     idx = Math.floor(idx % numFrames);
     const x = idx % framesPerRow;
     const y = Math.floor(idx / framesPerRow);
@@ -62,8 +68,8 @@ export function cacheTextureGenerator(
       textureSize * staticDevicePixelRatio,
       0,
       0,
-      textureSize,
-      textureSize
+      cellSize,
+      cellSize
     );
   };
 }

--- a/src/services/preact-canvas/components/board/style.css
+++ b/src/services/preact-canvas/components/board/style.css
@@ -7,7 +7,13 @@
   display: inline-block;
   opacity: 0;
   margin: auto;
-  padding: 70px 20px;
+  padding: 43px var(--side-margin);
+}
+
+@media (min-width: 320px) {
+  .game-table {
+    padding: 70px var(--side-margin);
+  }
 }
 
 .game-row {

--- a/src/services/preact-canvas/components/bottom-bar/style.css
+++ b/src/services/preact-canvas/components/bottom-bar/style.css
@@ -1,7 +1,7 @@
 .bottom-bar {
   display: flex;
   justify-content: flex-end;
-  margin: 20px;
+  margin: var(--side-margin);
   margin-top: 0;
   padding: 10px 0 0;
   position: fixed;
@@ -25,8 +25,8 @@
 .fullscreen {
   composes: unbutton from '../../utils.css';
   fill: #fff;
-  width: 24px;
-  height: 24px;
+  width: var(--icon-size);
+  height: var(--icon-size);
 }
 
 html:fullscreen .fullscreen {

--- a/src/services/preact-canvas/components/game/style.css
+++ b/src/services/preact-canvas/components/game/style.css
@@ -4,13 +4,19 @@
 
 .toggle-label {
   position: fixed;
-  bottom: 22px;
+  bottom: 10px;
   left: 50%;
   white-space: nowrap;
   transform: translateX(-50%);
   mix-blend-mode: screen;
   z-index: 1;
   cursor: pointer;
+}
+
+@media (min-width: 320px) {
+  .toggle-label {
+    bottom: 22px;
+  }
 }
 
 .toggle {

--- a/src/services/preact-canvas/components/top-bar/style.css
+++ b/src/services/preact-canvas/components/top-bar/style.css
@@ -27,15 +27,23 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  white-space: nowrap;
 }
 
 .title {
-  flex: 2;
+  display: none;
+  flex: 1;
   order: 2;
   text-align: center;
   font-size: inherit;
   margin: 0;
   padding: 0;
+}
+
+@media (min-width: 350px) {
+  .title {
+    display: block;
+  }
 }
 
 .time {
@@ -44,6 +52,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  white-space: nowrap;
 }
 
 .time-icon,

--- a/src/services/preact-canvas/components/top-bar/style.css
+++ b/src/services/preact-canvas/components/top-bar/style.css
@@ -1,6 +1,6 @@
 .top-bar {
   display: flex;
-  margin: 20px;
+  margin: var(--side-margin);
   margin-bottom: 0;
   padding: 0 0 10px;
   position: fixed;
@@ -57,8 +57,8 @@
 
 .time-icon,
 .square-icon {
-  width: 24px;
-  height: 24px;
+  width: var(--icon-size);
+  height: var(--icon-size);
   fill: #fff;
 }
 

--- a/src/services/preact-canvas/style.css
+++ b/src/services/preact-canvas/style.css
@@ -1,8 +1,22 @@
 html {
   /* Catch any browsers that still overscroll (eg Safari) */
   background-color: #000;
-  --cell-size: 40px;
-  --cell-padding: 5px;
+  --cell-size: 25px;
+  --cell-padding: 2px;
+  --side-margin: 10px;
+  --icon-size: 15px;
+  font-size: 0.7em;
+}
+
+/* We're assuming (totally safe, right?) that widths below 320 are feature phones */
+@media (min-width: 320px) {
+  html {
+    --cell-size: 40px;
+    --cell-padding: 9px;
+    --side-margin: 20px;
+    --icon-size: 24px;
+    font-size: 1em;
+  }
 }
 
 body {

--- a/src/services/preact-canvas/style.css
+++ b/src/services/preact-canvas/style.css
@@ -12,7 +12,7 @@ html {
 @media (min-width: 320px) {
   html {
     --cell-size: 40px;
-    --cell-padding: 9px;
+    --cell-padding: 5px;
     --side-margin: 20px;
     --icon-size: 24px;
     font-size: 1em;


### PR DESCRIPTION
Fixes #78. Fixes #76.

Now the textures scale if the cell size gets bigger. However, the cell padding cannot change, as that's part of the sprite, not part of the sprite-drawing.

@surma happy to revert the animation changes if you think it's better to regenerate the textures.

Smartphone size:

<img src="https://user-images.githubusercontent.com/93594/56221098-828ec680-6061-11e9-943b-e6f2b72abf69.png" width="400" />

Feature phone size:

![localhost_8081_(Banana Phone)](https://user-images.githubusercontent.com/93594/56221127-90444c00-6061-11e9-8f97-112c1861b741.png)
