### PR TITLE
Hacks because iOS is annoying

### DIFF
--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -243,7 +243,7 @@ export async function initTextureCaches(
   }
 
   // const size = textureSize * staticDevicePixelRatio;
-  const size = 2048;
+  const size = 1024;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,

--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -238,6 +238,7 @@ export function initTextureCaches(textureSize: number, cellPadding: number) {
     return;
   }
 
+  const size = textureSize;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,
@@ -246,13 +247,15 @@ export function initTextureCaches(textureSize: number, cellPadding: number) {
   idleAnimationTextureDrawer = cacheTextureGenerator(
     uncachedIATG,
     textureSize,
-    idleAnimationNumFrames
+    idleAnimationNumFrames,
+    { maxWidth: size, maxHeight: size }
   );
   const uncachedSTG = staticTextureGeneratorFactory(textureSize, cellPadding);
   staticTextureDrawer = cacheTextureGenerator(
     uncachedSTG,
     textureSize,
-    STATIC_TEXTURE.LAST_MARKER
+    STATIC_TEXTURE.LAST_MARKER,
+    { maxWidth: size, maxHeight: size }
   );
 }
 

--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -233,26 +233,30 @@ export function flashOutAnimation({
 let idleAnimationTextureDrawer: TextureDrawer | null = null;
 let staticTextureDrawer: TextureDrawer | null = null;
 
-export function initTextureCaches(textureSize: number, cellPadding: number) {
+export async function initTextureCaches(
+  textureSize: number,
+  cellPadding: number
+) {
   if (idleAnimationTextureDrawer) {
     // If we have one, we have them all.
     return;
   }
 
-  const size = textureSize * staticDevicePixelRatio;
+  // const size = textureSize * staticDevicePixelRatio;
+  const size = 2048;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,
     idleAnimationNumFrames
   );
-  idleAnimationTextureDrawer = cacheTextureGenerator(
+  idleAnimationTextureDrawer = await cacheTextureGenerator(
     uncachedIATG,
     textureSize,
     idleAnimationNumFrames,
     { maxWidth: size, maxHeight: size }
   );
   const uncachedSTG = staticTextureGeneratorFactory(textureSize, cellPadding);
-  staticTextureDrawer = cacheTextureGenerator(
+  staticTextureDrawer = await cacheTextureGenerator(
     uncachedSTG,
     textureSize,
     STATIC_TEXTURE.LAST_MARKER,
@@ -262,13 +266,5 @@ export function initTextureCaches(textureSize: number, cellPadding: number) {
 
 export async function lazyGenerateTextures() {
   const { cellPadding, cellSize } = getCellSizes();
-  initTextureCaches(cellSize + 2 * cellPadding, cellPadding);
-  await task();
-  const cvs = document.createElement("canvas");
-  cvs.width = cvs.height = 1;
-  const ctx = cvs.getContext("2d")!;
-  for (let i = 0; i < idleAnimationNumFrames; i++) {
-    idleAnimationTextureDrawer!(i, ctx, cellSize);
-    await task();
-  }
+  await initTextureCaches(cellSize + 2 * cellPadding, cellPadding);
 }

--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -233,17 +233,11 @@ export function flashOutAnimation({
 let idleAnimationTextureDrawer: TextureDrawer | null = null;
 let staticTextureDrawer: TextureDrawer | null = null;
 
-export async function initTextureCaches(
-  textureSize: number,
-  cellPadding: number
-) {
-  if (idleAnimationTextureDrawer) {
-    // If we have one, we have them all.
-    return;
-  }
+export async function lazyGenerateTextures() {
+  const { cellPadding, cellSize } = getCellSizes();
+  const textureSize = cellSize + 2 * cellPadding;
 
-  // const size = textureSize * staticDevicePixelRatio;
-  const size = 1024;
+  const spriteSize = 2048;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,
@@ -253,18 +247,13 @@ export async function initTextureCaches(
     uncachedIATG,
     textureSize,
     idleAnimationNumFrames,
-    { maxWidth: size, maxHeight: size }
+    { maxWidth: spriteSize, maxHeight: spriteSize }
   );
   const uncachedSTG = staticTextureGeneratorFactory(textureSize, cellPadding);
   staticTextureDrawer = await cacheTextureGenerator(
     uncachedSTG,
     textureSize,
     STATIC_TEXTURE.LAST_MARKER,
-    { maxWidth: size, maxHeight: size }
+    { maxWidth: spriteSize, maxHeight: spriteSize }
   );
-}
-
-export async function lazyGenerateTextures() {
-  const { cellPadding, cellSize } = getCellSizes();
-  await initTextureCaches(cellSize + 2 * cellPadding, cellPadding);
 }

--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -23,6 +23,7 @@ import {
   flashOutAnimationLength,
   idleAnimationLength,
   idleAnimationNumFrames,
+  spriteSize,
   turquoise
 } from "./constants.js";
 import { cacheTextureGenerator, TextureDrawer } from "./texture-cache.js";
@@ -237,7 +238,6 @@ export async function lazyGenerateTextures() {
   const { cellPadding, cellSize } = getCellSizes();
   const textureSize = cellSize + 2 * cellPadding;
 
-  const spriteSize = 2048;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,

--- a/src/rendering/animation.ts
+++ b/src/rendering/animation.ts
@@ -13,6 +13,7 @@
 
 import { getCellSizes } from "src/utils/cell-sizing.js";
 import { task } from "src/utils/scheduling.js";
+import { staticDevicePixelRatio } from "src/utils/static-dpr.js";
 import { easeInOutCubic, easeOutQuad, remap } from "./animation-helpers.js";
 import {
   fadedLinesAlpha,
@@ -238,7 +239,7 @@ export function initTextureCaches(textureSize: number, cellPadding: number) {
     return;
   }
 
-  const size = textureSize;
+  const size = textureSize * staticDevicePixelRatio;
   const uncachedIATG = idleAnimationTextureGeneratorFactory(
     textureSize,
     cellPadding,

--- a/src/rendering/constants.ts
+++ b/src/rendering/constants.ts
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export const spriteSize = 2048;
 
 export const numInnerRects = 5;
 // 3s delay per 8 fields
@@ -36,7 +37,7 @@ export const fadeOutAnimationLength = 300;
 export const flashInAnimationLength = 100;
 export const flashOutAnimationLength = 700;
 
-// Texture constanst
+// Texture constants
 export const fadedLinesAlpha = 0.3;
 export const safetyBufferFactor = 0.97;
 export const thickLine = 20 / 650;

--- a/src/rendering/texture-cache.ts
+++ b/src/rendering/texture-cache.ts
@@ -10,8 +10,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { task } from "../utils/scheduling";
 import { staticDevicePixelRatio } from "../utils/static-dpr.js";
 import { TextureGenerator } from "./texture-generators.js";
 
@@ -96,7 +94,7 @@ export async function cacheTextureGenerator(
     image.src = URL.createObjectURL(blob);
     await new Promise(r => (image.onload = r));
     caches[idx] = image;
-    await task();
+    await new Promise(r => setTimeout(r, 500));
   }
 
   return (

--- a/src/rendering/texture-cache.ts
+++ b/src/rendering/texture-cache.ts
@@ -10,6 +10,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { task } from "../utils/scheduling";
 import { staticDevicePixelRatio } from "../utils/static-dpr.js";
 import { TextureGenerator } from "./texture-generators.js";
 
@@ -94,7 +96,7 @@ export async function cacheTextureGenerator(
     image.src = URL.createObjectURL(blob);
     await new Promise(r => (image.onload = r));
     caches[idx] = image;
-    await new Promise(r => setTimeout(r, 500));
+    await task();
   }
 
   return (

--- a/src/services/preact-canvas/components/board/index.tsx
+++ b/src/services/preact-canvas/components/board/index.tsx
@@ -23,7 +23,6 @@ import {
   highlightInAnimation,
   highlightOutAnimation,
   idleAnimation,
-  initTextureCaches,
   numberAnimation
 } from "../../../../rendering/animation.js";
 import { bind } from "../../../../utils/bind.js";

--- a/src/services/preact-canvas/components/game/index.tsx
+++ b/src/services/preact-canvas/components/game/index.tsx
@@ -12,7 +12,6 @@
  */
 import { Remote } from "comlink/src/comlink";
 import { Component, h } from "preact";
-import { lazyGenerateTextures } from "src/rendering/animation";
 import StateService from "src/services/state";
 import { bind } from "src/utils/bind";
 import { GameChangeCallback } from "../..";
@@ -45,9 +44,7 @@ interface State {
 // tslint:disable-next-line:variable-name
 const End = deferred(import("../end/index.js").then(m => m.default));
 
-// The second this file is loaded, we start pregenerating our textures.
-lazyGenerateTextures();
-// …and activate focus handling
+// The second this file is loaded, activate focus handling
 initFocusHandling();
 
 export default class Game extends Component<Props, State> {

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -154,6 +154,10 @@ class PreactService extends Component<Props, State> {
   }
 
   private async _init(props: Props) {
+    texturePromise.then(() => {
+      this.setState({ texturesReady: true });
+    });
+
     const stateService = await props.stateServicePromise;
     this.setState({ stateService });
 
@@ -167,9 +171,6 @@ class PreactService extends Component<Props, State> {
         }
       }
     });
-
-    await texturePromise;
-    this.setState({ texturesReady: true });
   }
 }
 


### PR DESCRIPTION
Storing our textures as `<img>`, because iOS crashes if we keep them in memory as `<canvas>`. Just another day in the life of a web developer.