### PR TITLE
Initial service worker

### DIFF
--- a/consts-plugin.js
+++ b/consts-plugin.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default function constsPlugin(consts) {
+  return {
+    name: "consts-plugin",
+    async resolveId(id) {
+      if (id !== "consts:") {
+        return;
+      }
+      return id;
+    },
+    load(id) {
+      if (id !== "consts:") {
+        return;
+      }
+      return Object.entries(consts)
+        .map(
+          ([key, value]) => `export const ${key} = ${JSON.stringify(value)};`
+        )
+        .join("");
+    }
+  };
+}

--- a/resource-list-plugin.js
+++ b/resource-list-plugin.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const resourceListMarker = "___REPLACE_THIS_WITH_RESOURCE_LIST_LATER";
+
+export default function resourceList() {
+  return {
+    name: "dependencygraph",
+    resolveId(id) {
+      if (id !== "resource-list:") {
+        return null;
+      }
+      return id;
+    },
+    load(id) {
+      if (id !== "resource-list:") {
+        return null;
+      }
+      return `export default ${resourceListMarker};`;
+    },
+    generateBundle(_outputOptions, bundle) {
+      const resourceListJSON = JSON.stringify(Object.keys(bundle));
+
+      for (const item of Object.values(bundle)) {
+        if (!item.code) {
+          continue;
+        }
+        item.code = item.code.replace(resourceListMarker, resourceListJSON);
+      }
+    }
+  };
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,22 +17,27 @@ import { terser } from "rollup-plugin-terser";
 import loadz0r from "rollup-plugin-loadz0r";
 import dependencyGraph from "./dependency-graph-plugin.js";
 import chunkNamePlugin from "./chunk-name-plugin.js";
+import resourceListPlugin from "./resource-list-plugin";
 import postcss from "rollup-plugin-postcss";
 import glsl from "./glsl-plugin.js";
 import cssModuleTypes from "./css-module-types.js";
 import assetPlugin from "./asset-plugin.js";
 import { readFileSync } from "fs";
+import constsPlugin from "./consts-plugin.js";
 
 // Delete 'dist'
 require("rimraf").sync("dist");
 
 export default {
-  input: "src/bootstrap.ts",
+  input: {
+    bootstrap: "src/bootstrap.ts",
+    sw: "src/sw/index.ts"
+  },
   output: {
     dir: "dist",
     format: "amd",
     sourcemap: true,
-    entryFileNames: "[name]-[hash].js",
+    entryFileNames: "[name].js",
     chunkFileNames: "[name]-[hash].js"
   },
   plugins: [
@@ -46,6 +51,9 @@ export default {
       namedExports(name) {
         return name.replace(/-\w/g, val => val.slice(1).toUpperCase());
       }
+    }),
+    constsPlugin({
+      version: require("./package.json").version
     }),
     typescript({
       // Make sure we are using our version of TypeScript.
@@ -87,6 +95,7 @@ export default {
     dependencyGraph({
       propList: ["facadeModuleId", "fileName", "imports", "code", "isAsset"]
     }),
+    resourceListPlugin(),
     terser()
   ]
 };

--- a/sizereport.config.js
+++ b/sizereport.config.js
@@ -1,18 +1,5 @@
-const { parse } = require("path");
-const rescapeRE = require("escape-string-regexp");
-
 module.exports = {
   repo: "GoogleChromeLabs/graviton",
   path: "dist/**/*",
-  branch: "master",
-  findRenamed(path, newPaths) {
-    const parsedPath = parse(path);
-    if (parsedPath.base.startsWith("bootstrap-")) {
-      const end = /\..*$/.exec(parsedPath.base)[0];
-      const re = new RegExp(
-        `^${rescapeRE(parsedPath.dir)}/bootstrap-[^\.]+${end}$`
-      );
-      return newPaths.find(path => re.test(path));
-    }
-  }
+  branch: "master"
 };

--- a/src/missing-types.d.ts
+++ b/src/missing-types.d.ts
@@ -3,6 +3,15 @@ declare module "chunk-name:*" {
   export default value;
 }
 
+declare module "resource-list:" {
+  const value: string[];
+  export default value;
+}
+
+declare module "consts:" {
+  export const version: string;
+}
+
 interface Window {
   debug?: Promise<typeof import("./services/debug/index.js")>;
 }

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -1,0 +1,81 @@
+/** Tell the service worker to skip waiting */
+export async function skipWaiting() {
+  const reg = await navigator.serviceWorker.getRegistration();
+  if (!reg || !reg.waiting) {
+    return;
+  }
+  reg.waiting.postMessage("skip-waiting");
+
+  return new Promise(resolve => {
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      () => resolve(),
+      { once: true }
+    );
+  });
+}
+
+export let updateReady = false;
+
+/** Wait for an installing worker */
+async function installingWorker(
+  reg: ServiceWorkerRegistration
+): Promise<ServiceWorker> {
+  if (reg.installing) {
+    return reg.installing;
+  }
+  return new Promise<ServiceWorker>(resolve => {
+    reg.addEventListener("updatefound", () => resolve(reg.installing!), {
+      once: true
+    });
+  });
+}
+
+async function watchForUpdate() {
+  const hasController = !!navigator.serviceWorker.controller;
+
+  // If we don't have a controller, we don't need to check for updates – we've just loaded from the
+  // network.
+  if (!hasController) {
+    return;
+  }
+
+  const reg = await navigator.serviceWorker.getRegistration();
+  // Service worker not registered yet.
+  if (!reg) {
+    return;
+  }
+
+  // Look for updates
+  if (reg.waiting) {
+    return;
+  }
+  const installing = await installingWorker(reg);
+  await new Promise<void>(resolve => {
+    installing.addEventListener("statechange", () => {
+      if (installing.state === "installed") {
+        resolve();
+      }
+    });
+  });
+
+  updateReady = true;
+}
+
+/** Set up the service worker and monitor changes */
+export async function init() {
+  const thisURL = new URL(location.href);
+
+  if (thisURL.searchParams.has("no-sw")) {
+    const reg = await navigator.serviceWorker.getRegistration();
+    if (reg) {
+      await reg.unregister();
+      location.reload();
+    }
+    return;
+  }
+
+  await navigator.serviceWorker.register("/sw.js");
+
+  watchForUpdate();
+}

--- a/src/offline/index.ts
+++ b/src/offline/index.ts
@@ -1,4 +1,4 @@
-/** Tell the service worker to skip waiting */
+/** Tell the service worker to skip waiting. Resolves once the controller has changed. */
 export async function skipWaiting() {
   const reg = await navigator.serviceWorker.getRegistration();
   if (!reg || !reg.waiting) {
@@ -15,6 +15,7 @@ export async function skipWaiting() {
   });
 }
 
+/** Is there currently a waiting worker? */
 export let updateReady = false;
 
 /** Wait for an installing worker */
@@ -76,6 +77,5 @@ export async function init() {
   }
 
   await navigator.serviceWorker.register("/sw.js");
-
   watchForUpdate();
 }

--- a/src/services/preact-canvas/components/game-loading/index.tsx
+++ b/src/services/preact-canvas/components/game-loading/index.tsx
@@ -14,7 +14,6 @@ import { Component, h } from "preact";
 import TopBar from "../top-bar/index.js";
 import { loading, loadingInner } from "./style.css";
 
-// tslint:disable-next-line:max-classes-per-file
 export default class GameLoading extends Component<{}, {}> {
   render() {
     return (

--- a/src/services/preact-canvas/components/game-loading/index.tsx
+++ b/src/services/preact-canvas/components/game-loading/index.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, h } from "preact";
+import TopBar from "../top-bar/index.js";
+import { loading, loadingInner } from "./style.css";
+
+// tslint:disable-next-line:max-classes-per-file
+export default class GameLoading extends Component<{}, {}> {
+  render() {
+    return (
+      <div class={loading}>
+        <TopBar titleOnly />
+        <div class={loadingInner}>…Loading…</div>
+      </div>
+    );
+  }
+}

--- a/src/services/preact-canvas/components/game-loading/style.css
+++ b/src/services/preact-canvas/components/game-loading/style.css
@@ -1,0 +1,25 @@
+.loading {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+@keyframes fade-in-out {
+  50% {
+    opacity: 1;
+  }
+}
+
+.loadingInner {
+  display: flex;
+  flex-flow: column;
+  padding: var(--bar-avoid) var(--side-margin) 0;
+  box-sizing: border-box;
+  width: 100%;
+  text-align: center;
+  font-size: 2.3rem;
+  opacity: 0;
+  animation: fade-in-out 3s ease-in-out infinite 0.5s;
+}

--- a/src/services/preact-canvas/components/intro/index.tsx
+++ b/src/services/preact-canvas/components/intro/index.tsx
@@ -25,8 +25,6 @@ import {
   selectArrow as selectArrowStyle,
   settingsRow as settingsRowStyle,
   startButton as startButtonStyle,
-  startButtonTextHide,
-  startButtonTextShow,
   startForm as startFormStyle
 } from "./style.css";
 
@@ -93,7 +91,6 @@ type PresetName = keyof typeof presets;
 
 export interface Props {
   onStartGame: (width: number, height: number, mines: number) => void;
-  loading: boolean;
 }
 
 interface State {
@@ -101,14 +98,12 @@ interface State {
   width: number;
   height: number;
   mines: number;
-  longLoad: boolean;
 }
 
 // tslint:disable-next-line:max-classes-per-file
 export default class Intro extends Component<Props, State> {
   state: State = {
     presetName: "beginner",
-    longLoad: false,
     ...presets.beginner
   };
 
@@ -119,16 +114,9 @@ export default class Intro extends Component<Props, State> {
 
   componentDidMount() {
     window.scrollTo(0, 0);
-
-    setTimeout(() => {
-      this.setState({ longLoad: true });
-    }, 1000);
   }
 
-  render(
-    { loading }: Props,
-    { width, height, mines, presetName, longLoad }: State
-  ) {
+  render(_props: Props, { width, height, mines, presetName }: State) {
     return (
       <div class={introStyle}>
         <TopBar titleOnly />
@@ -185,21 +173,7 @@ export default class Intro extends Component<Props, State> {
             </NumberField>
           </div>
           <div class={settingsRowStyle}>
-            <button class={startButtonStyle} disabled={loading}>
-              <span
-                class={
-                  longLoad || !loading
-                    ? startButtonTextShow
-                    : startButtonTextHide
-                }
-              >
-                {loading
-                  ? longLoad
-                    ? "…Loading…"
-                    : "\u00A0" // non-breaking space, to retain height
-                  : "Start"}
-              </span>
-            </button>
+            <button class={startButtonStyle}>Start</button>
           </div>
         </form>
       </div>

--- a/src/services/preact-canvas/components/intro/style.css
+++ b/src/services/preact-canvas/components/intro/style.css
@@ -108,21 +108,4 @@
   margin: 0 var(--item-margin) !important;
   text-transform: uppercase;
   letter-spacing: 0.15rem;
-  will-change: opacity;
-  transition: opacity 0.4s ease-in-out;
-}
-
-.start-button:disabled {
-  opacity: 0.7;
-}
-
-.start-button-text-hide {
-  will-change: opacity;
-  opacity: 0;
-  transition: opacity 0.2s ease-in-out;
-}
-
-.start-button-text-show {
-  composes: start-button-text-hide;
-  opacity: 1;
 }

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -31,7 +31,6 @@ interface Props {
 interface State {
   game?: GameType;
   dangerMode: boolean;
-  texturesReady: boolean;
   awaitingGame: boolean;
 }
 
@@ -58,7 +57,6 @@ const immedateGameSessionKey = "instantGame";
 class PreactService extends Component<Props, State> {
   state: State = {
     dangerMode: false,
-    texturesReady: false,
     awaitingGame: false
   };
 
@@ -167,10 +165,6 @@ class PreactService extends Component<Props, State> {
     }
 
     offlineModulePromise.then(({ init }) => init());
-
-    texturePromise.then(() => {
-      this.setState({ texturesReady: true });
-    });
 
     this._stateService = await stateServicePromise;
 

--- a/src/services/preact-canvas/index.tsx
+++ b/src/services/preact-canvas/index.tsx
@@ -24,6 +24,10 @@ import GameLoading from "./components/game-loading";
 import Intro from "./components/intro/index.js";
 import { game as gameClassName, main } from "./style.css";
 
+// If the user tries to start a game when we aren't ready, how long do we wait before showing the
+// loading screen?
+const loadingScreenTimeout = 1000;
+
 interface Props {
   stateServicePromise: Promise<Remote<StateService>>;
 }
@@ -147,7 +151,7 @@ class PreactService extends Component<Props, State> {
 
     this._awaitingGameTimeout = setTimeout(() => {
       this.setState({ awaitingGame: true });
-    }, 1000);
+    }, loadingScreenTimeout);
 
     // Wait for everything to be ready:
     await texturePromise;

--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -1,0 +1,43 @@
+import { version } from "consts:";
+import resourceList from "resource-list:";
+// Give TypeScript the correct global.
+declare var self: ServiceWorkerGlobalScope;
+
+const staticCache = `static-${version}`;
+
+self.addEventListener("install", event => {
+  const toCache = resourceList.filter(item => item !== "sw.js");
+
+  event.waitUntil(
+    (async function() {
+      const cache = await caches.open(staticCache);
+      await cache.addAll(toCache);
+    })()
+  );
+});
+
+self.addEventListener("activate", event => {
+  event.waitUntil(
+    (async function() {
+      const cacheNames = await caches.keys();
+      for (const cacheName of cacheNames) {
+        if (cacheName === staticCache) {
+          continue;
+        }
+        await caches.delete(cacheName);
+      }
+    })()
+  );
+});
+
+self.addEventListener("fetch", event => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+  event.respondWith(
+    (async function() {
+      const cachedResponse = await caches.match(event.request);
+      return cachedResponse || fetch(event.request);
+    })()
+  );
+});

--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -6,7 +6,9 @@ declare var self: ServiceWorkerGlobalScope;
 const staticCache = `static-${version}`;
 
 self.addEventListener("install", event => {
-  const toCache = resourceList.filter(item => item !== "sw.js");
+  const toCache = resourceList.filter(
+    item => item !== "sw.js" && item !== "bootstrap.js"
+  );
 
   event.waitUntil(
     (async function() {

--- a/src/sw/missing-types.d.ts
+++ b/src/sw/missing-types.d.ts
@@ -1,0 +1,1 @@
+import "../missing-types";

--- a/src/sw/tsconfig.json
+++ b/src/sw/tsconfig.json
@@ -4,13 +4,9 @@
     "target": "es5",
     "downlevelIteration": true,
     "module": "esnext",
-    "jsx": "react",
-    "jsxFactory": "h",
     "strict": true,
-    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
+    "lib": ["esnext", "webworker"],
     "moduleResolution": "node",
     "baseUrl": "./",
-    "types": []
-  },
-  "exclude": ["src/sw/**/*"]
+  }
 }


### PR DESCRIPTION
Ready for review!

The service worker will install during dev. Add `?no-sw` to the end of the page URL to disable it.

I spent a while trying to find a good place for an "update available" message, but then I thought: can we avoid it? In this PR I don't show a message, but if the user presses "start" when there's a update available, it'll perform the update *then* start the game.

I refactored our loading state as part of this. We were giving too much away by disabling/dimming the start button. The user can press start whenever they want, we only have to admit we aren't ready if they beat us to it. I implemented that flow in this PR.